### PR TITLE
Add the ability to support inspecting gRPC (protobuf) content.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Updated helloworld example to be more configurable allowing it to be used in other example documentation
+* Added the ability to support inspecting gRPC (protobuf) content
 
 ## 1.6.2 2019-08-25
 


### PR DESCRIPTION
This adds some features to support inspecting gRPC (protobuf) content.

* Support the `application/grpc` content type
* Allow sending the body for unknown content lengths (`http.Request.ContentLength == -1`)